### PR TITLE
fix: changing function name to avoid conflicts

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -134,7 +134,7 @@ Returns the port for NGINX Prometheus Exporter
 {{/*
 Returns the full ingress host.
 */}}
-{{- define "ingress.host" -}}
+{{- define "nginx.ingress.host" -}}
 {{- $fullName := include "nginx.fullname" . -}}
 {{- if .Values.ingress.host }}
     {{- .Values.ingress.host -}}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := include "nginx.name" . -}}
-{{- $ingressHost := include "ingress.host" . -}}
+{{- $ingressHost := include "nginx.ingress.host" . -}}
 {{- if and (.Values.enabled) (.Values.ingress.enabled) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Why Shared Function Names in Helm Charts Cause Problems?

Background:
We ran into trouble when deploying our Helm charts because we used the same function names in different parts of the charts.(in ""common-nginx" and "catalog-manager"

Incident Description:
Our deployments failed because the function names clashed, making it hard for Helm to understand to which function he should reference.

Resolution:
1.Naming Convention: Using convention where function names start with the chart's name, ensuring uniqueness.
2.Common helm: We should create central common-helm as sub-chart to all other helms with shared functions to reduce duplication and future Collision.