### PR TITLE
chore: changed container name to app's fullName

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             {{ tpl (toYaml .Values.extraVolumes) . | nindent 8 }}
           {{- end }}
       containers:
-        - name: nginx-container
+        - name: {{ $fullName | quote }}
           {{- with .Values.image }}
           image: {{ $cloudProviderDockerRegistryUrl }}{{ .repository }}:{{ .tag }}
           {{- end }}


### PR DESCRIPTION
Instead of the hard coded "nginx-container". Needed for splunk filters.