### PR TITLE
helm: add Access-Control-Max-Age header to Nginx configuration

### DIFF
--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -1,6 +1,8 @@
 server {
     listen 8080;
     server_name  localhost;
+    # In case you use "add_header" in the location block, this "add_header" will be ignored!
+    add_header 'Access-Control-Max-Age' '{{ .Values.env.nginx.maxAge | default "7200" }}';
 
     location / {
         set $original_method $request_method;

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -119,6 +119,11 @@ env:
     # -- Use OpenTelemetry parnet-based sampling
     parentBased: "false" # true, false
 
+  # @section -- Nginx Configuration
+  nginx:
+    # -- Maximum age of the cache in seconds (for the header: Access-Control-Max-Age)
+    maxAge: 
+
   # @section -- NGINX-Prometheus-Exporter Parameters
 prometheusExporter:
     # -- Enable or disable the Prometheus exporter sidecar


### PR DESCRIPTION
Introduce a max-age header in the Nginx configuration to control caching behavior. Update the configuration to allow customization of the max-age value.

Teams still need to add the header to their default.conf