### PR TITLE
helm: allow adding additional nginx conf

### DIFF
--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -6,7 +6,13 @@ split_clients "$otel_trace_id" $ratio_sampler {
 server {
     listen 8080;
     server_name  localhost;
-    # In case you use "add_header" in the location block, this "add_header" will be ignored!
+
+    # Include external configuration file if "additionalConf" is set to true in values.yaml
+    {{- if .Values.nginx.additionalConf.enabled }}
+    include /etc/nginx/conf.d/{{ .Values.nginx.additionalConf.fileName }};
+    {{- end }}
+
+    # In case you use "add_header" in the location block, these "add_header" will be ignored!
     add_header 'Access-Control-Max-Age' '{{ .Values.nginx.maxAge | default "7200" }}';
     add_header 'Access-Control-Allow-Origin' {{ .Values.nginx.allowedOrigins | default "*" | squote }};
     add_header 'Access-Control-Allow-Headers' {{ .Values.nginx.allowedHeaders | default "*" | squote }};

--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -20,7 +20,7 @@ server {
     location / {
       if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' {{ .Values.nginx.allowedOrigins | default "*" | squote }};
-        add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+        add_header 'Access-Control-Allow-Methods' {{ .Values.nginx.allowedMethods | default "GET, OPTIONS" | squote }};
         #
         # Custom headers and headers various browsers *should* be OK with but aren't
         #

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -71,9 +71,9 @@ spec:
               mountPath: "/etc/nginx/log_format.conf"
               subPath: log_format.conf
             {{- end -}}
-              {{- if .Values.extraVolumeMounts }}
-                {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
-              {{- end }} 
+            {{- if .Values.extraVolumeMounts }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }} 
           ports:
             - name: http
               containerPort: {{ .Values.targetPort }}

--- a/helm/values.md
+++ b/helm/values.md
@@ -45,8 +45,11 @@ A Helm chart for nginx
 | ingress.tls.secretName | string | `""` | Secret name of ingress that points to the relevant custom certificates |
 | initialDelaySeconds | int | `60` | Initial delay in seconds before the readiness probe starts |
 | nameOverride | string | `""` | String to partially override fullname template (will maintain the release name) |
-| nginx.allowedHeaders | string | `nil` | Allowed headers (comma-seperated, for the header: Access-Control-Allow-Headers) |
-| nginx.allowedOrigins | string | `nil` | Allowed origins (comma-seperated, for the header: Access-Control-Allow-Origin) |
+| nginx.additionalConf.enabled | bool | `false` | Enable or disable the inclusion of an additional configuration file in the NGINX configuration |
+| nginx.additionalConf.fileName | string | `"additional.conf"` | Name of the additional configuration file to be included in the NGINX configuration (should be mounted to the "config" directory) |
+| nginx.allowedHeaders | string | `nil` | Allowed headers, default: * (comma-seperated, for the header: Access-Control-Allow-Headers) |
+| nginx.allowedMethods | string | `nil` | Allowed methods, default: GET, OPTIONS (comma-seperated, for the header: Access-Control-Allow-Methods) |
+| nginx.allowedOrigins | string | `nil` | Allowed origins, default: * (comma-seperated, for the header: Access-Control-Allow-Origin) |
 | nginx.maxAge | string | `nil` | Maximum age of the cache in seconds (for the header: Access-Control-Max-Age) |
 | nginx.optionsMaxAge | string | `nil` | Maximum age of the OPTIONS cache in seconds (for the header: Access-Control-Max-Age) |
 | nodePort | int | `30001` | Port to expose on each node for NodePort service type |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -136,6 +136,8 @@ nginx:
   allowedOrigins:
   # -- Allowed headers, default: * (comma-seperated, for the header: Access-Control-Allow-Headers)
   allowedHeaders:
+  # -- Allowed methods, default: GET, OPTIONS (comma-seperated, for the header: Access-Control-Allow-Methods)
+  allowedMethods:
   # -- Maximum age of the OPTIONS cache in seconds (for the header: Access-Control-Max-Age)
   optionsMaxAge:
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -125,11 +125,16 @@ opentelemetry:
 
 # @section -- Nginx Configuration
 nginx:
+  additionalConf:
+    # -- Enable or disable the inclusion of an additional configuration file in the NGINX configuration
+    enabled: false
+    # -- Name of the additional configuration file to be included in the NGINX configuration (should be mounted to the "config" directory)
+    fileName: additional.conf
   # -- Maximum age of the cache in seconds (for the header: Access-Control-Max-Age)
   maxAge:
-  # -- Allowed origins (comma-seperated, for the header: Access-Control-Allow-Origin)
+  # -- Allowed origins, default: * (comma-seperated, for the header: Access-Control-Allow-Origin)
   allowedOrigins:
-  # -- Allowed headers (comma-seperated, for the header: Access-Control-Allow-Headers)
+  # -- Allowed headers, default: * (comma-seperated, for the header: Access-Control-Allow-Headers)
   allowedHeaders:
   # -- Maximum age of the OPTIONS cache in seconds (for the header: Access-Control-Max-Age)
   optionsMaxAge:


### PR DESCRIPTION
Some services using this package as a dependency need to add custom `locations` or other definitions. This means there is a need to allow expanding the basic `default.conf` file with additional srvice-specific definitions.
In order to add the additional file, it should be mounted under `/etc/nginx/conf.d` directive and added in the `extraVolumeMounts` value.