### PR TITLE
refactor(helm): move otel_trace directive to server scope

### DIFF
--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -12,6 +12,9 @@ server {
     include /etc/nginx/conf.d/{{ .Values.nginx.additionalConf.fileName }};
     {{- end }}
 
+    # Include OpenTelemetry tracing configuration
+    {{ include "nginx.otelTrace" . | nindent 4 }}
+
     # In case you use "add_header" in the location block, these "add_header" will be ignored!
     add_header 'Access-Control-Max-Age' '{{ .Values.nginx.maxAge | default "7200" }}';
     add_header 'Access-Control-Allow-Origin' {{ .Values.nginx.allowedOrigins | default "*" | squote }};
@@ -33,8 +36,6 @@ server {
         add_header 'Content-Length' 0;
         return 204;
       }
-
-      {{ include "nginx.otelTrace" . | nindent 8 }}
 
       set $original_method $request_method;
       set $original_args $args;


### PR DESCRIPTION
Move the otel_trace directive from the location / block to the server block in [default.conf](vscode-file://vscode-app/snap/code/228/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
This ensures tracing is applied to all locations in the server (not just /).