### PR TITLE
feat: changed opa headers mechanism from whitelist to blacklist

### DIFF
--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -1,5 +1,51 @@
 import qs from "querystring";
 
+const DENYLIST = {
+  // Payloads
+  cookie: true,
+  authorization: true,
+
+  // Connection / Hop-by-Hop (Network Noise)
+  connection: true,
+  "keep-alive": true,
+  "transfer-encoding": true,
+  te: true,
+  trailer: true,
+  upgrade: true,
+
+  // Cache State (State Noise)
+  "cache-control": true,
+  pragma: true,
+  "if-match": true,
+  "if-none-match": true,
+  "if-modified-since": true,
+  "if-unmodified-since": true,
+
+  // Browser Privacy / Legacy (Unused Bloat)
+  dnt: true,
+  "sec-gpc": true,
+  "upgrade-insecure-requests": true,
+  "save-data": true,
+
+  // Legacy Tracing (Dropping B3/Zipkin, implicitly keeping Otel W3C)
+  b3: true,
+  "x-b3-traceid": true,
+  "x-b3-spanid": true,
+  "x-b3-sampled": true,
+};
+
+function filterHeaders(r) {
+  let cleanHeaders = {};
+
+  for (let header in r.headersIn) {
+    if (!DENYLIST[header.toLowerCase()]) {
+      cleanHeaders[header] = r.headersIn[header];
+    }
+  }
+
+  return cleanHeaders;
+}
+
 async function opaAuth(r) {
   try {
     if (r.variables.original_method == "OPTIONS") {
@@ -9,25 +55,7 @@ async function opaAuth(r) {
     const body = {
       input: {
         method: r.variables.original_method,
-        headers: {
-          'user-agent': r.headersIn['user-agent'],
-          'origin': r.headersIn['origin'],
-          'referer': r.headersIn['referer'],
-          
-          // --- Custom Authentication ---
-          'x-api-key': r.headersIn['x-api-key'],
-                    
-          // --- Routing & Proxy Context ---
-          'host': r.headersIn['host'],
-          'x-forwarded-for': r.headersIn['x-forwarded-for'],
-          'x-forwarded-host': r.headersIn['x-forwarded-host'],
-          'x-forwarded-proto': r.headersIn['x-forwarded-proto'],
-          'x-real-ip': r.headersIn['x-real-ip'],
-                    
-          // --- Payload Context ---
-          'content-type': r.headersIn['content-type'],
-          'content-length': r.headersIn['content-length'],
-        },
+        headers: filterHeaders(r),
         query: qs.parse(r.variables.original_args),
         domain: r.variables.domain,
       },

--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -4,7 +4,7 @@ const DENYLIST = {
   // Payloads
   cookie: true,
   authorization: true,
-
+  "proxy-authorization": true,
   // Connection / Hop-by-Hop (Network Noise)
   connection: true,
   "keep-alive": true,

--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -34,15 +34,36 @@ const DENYLIST = {
   "x-b3-sampled": true,
 };
 
+// 2. Size Limit Configuration
+const MAX_HEADER_LENGTH = 2048;
+
+// 3. Exceptions to the size limit (Headers that are allowed to be large)
+const LENGTH_EXCEPTIONS = {
+  "x-api-key": true,
+  referer: true,
+};
+
 function filterHeaders(r) {
+  // Object.create(null) creates a pure dictionary with no prototype chain,
+  // protecting against prototype pollution/injection attacks.
   const cleanHeaders = Object.create(null);
 
   for (const header in r.headersIn) {
-    if (!Object.prototype.hasOwnProperty.call(r.headersIn, header)) continue;
+    // Protect against inherited properties injection
+    if (!Object.prototype.hasOwnProperty.call(r.headersIn, header)) {
+      continue;
+    }
 
     const key = header.toLowerCase();
+
     if (!DENYLIST[key]) {
-      cleanHeaders[key] = r.headersIn[header];
+      const headerValue = r.headersIn[header];
+
+      if (headerValue.length > MAX_HEADER_LENGTH && !LENGTH_EXCEPTIONS[key]) {
+        cleanHeaders[key] = "[REDACTED_SIZE_LIMIT]";
+      } else {
+        cleanHeaders[key] = headerValue;
+      }
     }
   }
 

--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -35,11 +35,14 @@ const DENYLIST = {
 };
 
 function filterHeaders(r) {
-  let cleanHeaders = {};
+  const cleanHeaders = Object.create(null);
 
-  for (let header in r.headersIn) {
-    if (!DENYLIST[header.toLowerCase()]) {
-      cleanHeaders[header] = r.headersIn[header];
+  for (const header in r.headersIn) {
+    if (!Object.prototype.hasOwnProperty.call(r.headersIn, header)) continue;
+
+    const key = header.toLowerCase();
+    if (!DENYLIST[key]) {
+      cleanHeaders[key] = r.headersIn[header];
     }
   }
 

--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -57,7 +57,9 @@ function filterHeaders(r) {
     const key = header.toLowerCase();
 
     if (!DENYLIST[key]) {
-      const headerValue = r.headersIn[header];
+      const headerValue = Array.isArray(r.headersIn[header])
+        ? r.headersIn[header].join(", ")
+        : r.headersIn[header];
 
       if (headerValue.length > MAX_HEADER_LENGTH && !LENGTH_EXCEPTIONS[key]) {
         cleanHeaders[key] = "[REDACTED_SIZE_LIMIT]";


### PR DESCRIPTION
**Description:**
This PR refactors the NGINX `njs` script to transition our OPA header filtering from an allowlist (whitelist) to a denylist (blocklist).

**Key benefits of this change:**

* **Enabled zero-friction policy updates:** I removed the need for NGINX deployments just to add new headers. Future custom headers for new policies will now automatically flow through to OPA.
* **Improved observability and debugging:** Header typos are no longer silently dropped at the edge. Invalid or misspelled headers now reach OPA and appear in the decision logs, making troubleshooting much faster.
* **Maintained performance & reduced log bloat:** I implemented a highly optimized, O(1) module-level denylist to explicitly strip out heavy, irrelevant payloads (`Cookie`, raw `Authorization`, legacy tracing, and cache/network noise). This ensures we keep request latency low and OPA payload sizes lean.