### PR TITLE
build: upgrade nginx base image to 1.29.8

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:1.28.0-alpine3.21-otel
+FROM nginxinc/nginx-unprivileged:1.29.8-alpine3.23-otel
 
 USER root
 


### PR DESCRIPTION
## What

Bump the base image from `nginxinc/nginx-unprivileged:1.28.0-alpine3.21-otel` to `1.29.8-alpine3.23-otel`.

## Why

- Newer nginx runtime + OpenTelemetry module.
- nginx ≥ 1.27.3 is required for `server … resolve;` runtime DNS re-resolution used by downstream consumers (nginx-s3-gateway).
- Unblocks the nginx-s3-gateway "reuse this base image" work.

## Verification

- `docker build` green; `nginx -v` → **nginx/1.29.8**.
- `auth.js` + `status_site.conf` unchanged and present.
- njs `import` of `auth.js` resolves; `opaAuth` / `jwtPayloadSub` export as functions.
- With the otel module loaded (as at runtime), `otel_trace` is recognized and a full config `nginx -t` passes.

## Note

Only the `FROM` line changes. On merge + release, CI publishes `common/nginx:v<release>` carrying nginx 1.29.8 — downstream should pin to that release tag.