### PR TITLE
feat(auth): export buildOpaBody for reuse by dependent gateways

### DIFF
--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -72,9 +72,6 @@ function filterHeaders(r) {
   return cleanHeaders;
 }
 
-// Builds the OPA request body (as a JSON string) from the current request.
-// Exported so gateways that reuse this base image (e.g. nginx-s3-gateway)
-// send OPA an identical input contract instead of reconstructing it.
 function buildOpaBody(r) {
   return JSON.stringify({
     input: {

--- a/docker-image/nginx-config/auth.js
+++ b/docker-image/nginx-config/auth.js
@@ -72,23 +72,28 @@ function filterHeaders(r) {
   return cleanHeaders;
 }
 
+// Builds the OPA request body (as a JSON string) from the current request.
+// Exported so gateways that reuse this base image (e.g. nginx-s3-gateway)
+// send OPA an identical input contract instead of reconstructing it.
+function buildOpaBody(r) {
+  return JSON.stringify({
+    input: {
+      method: r.variables.original_method,
+      headers: filterHeaders(r),
+      query: qs.parse(r.variables.original_args),
+      domain: r.variables.domain,
+    },
+  });
+}
+
 async function opaAuth(r) {
   try {
     if (r.variables.original_method == "OPTIONS") {
       return r.return(204);
     }
 
-    const body = {
-      input: {
-        method: r.variables.original_method,
-        headers: filterHeaders(r),
-        query: qs.parse(r.variables.original_args),
-        domain: r.variables.domain,
-      },
-    };
-
     const response = await r.subrequest("/opa", {
-      body: JSON.stringify(body),
+      body: buildOpaBody(r),
       method: "POST",
     });
 
@@ -145,4 +150,4 @@ function jwtPayloadSub(r) {
   }
 }
 
-export default { opaAuth, jwtPayloadSub };
+export default { opaAuth, jwtPayloadSub, buildOpaBody };


### PR DESCRIPTION
## What

Extracts the OPA request-body construction out of `opaAuth` into an exported `buildOpaBody(r)` helper in `auth.js`.

## Why

Gateways that build **on top of this base image** (e.g. `nginx-s3-gateway`, which reuses this image for shared OPA/JWT auth) run a *combined* OPA→credentials auth handler in a single njs call, so they can't just call `opaAuth` (which does its own subrequest + `r.return`). They were **rebuilding the OPA input themselves** — and had drifted to a stale explicit header **whitelist**, diverging from this image's current denylist filtering (`filterHeaders`: blocklist + 2KB size-redaction + prototype-pollution guard).

Exporting the builder lets those gateways produce an **identical OPA input contract** instead of maintaining a divergent copy.

## Change

- New `buildOpaBody(r)` — returns the `{ input: { method, headers: filterHeaders(r), query, domain } }` body as a JSON string.
- `opaAuth` now calls it (pure extraction — **behavior unchanged**).
- Added to the default export: `{ opaAuth, jwtPayloadSub, buildOpaBody }`.

## Verification

- njs/ES syntax check passes.
- No behavioral change to `opaAuth` — same body, same flow.
